### PR TITLE
Mysteriously remove workaround for GHC bug

### DIFF
--- a/plutus-playground/plutus-playground-server/src/Playground/Interpreter.hs
+++ b/plutus-playground/plutus-playground-server/src/Playground/Interpreter.hs
@@ -154,7 +154,10 @@ runghcOpts =
     , "-XScopedTypeVariables"
     , "-O0"
     -- FIXME: workaround for https://ghc.haskell.org/trac/ghc/ticket/16228
-    , "-package plutus-tx"
+    -- This appears to sometimes be necessary and sometimes not be, depending 
+    -- on apparently unrelated changes in the packages this depends on. I'm
+    -- blaming the GHC bug.
+    --, "-package plutus-tx"
     ]
 
 lookupRunghc :: (MonadIO m, MonadError PlaygroundError m) => m String


### PR DESCRIPTION
I'm baffled by this. It's toggled from the workaround being needed to
make it work, to the workaround making it *not* work. I'm chalking this
up to the GHC bug being more insidious than we thought.